### PR TITLE
Upgrade Django to version 4.2.22

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,6 +1,6 @@
-asgiref==3.2.7
-Django==3.0.5
-pytz==2019.3
-sqlparse==0.3.1
-djangorestframework==3.11.0
-psycopg2-binary==2.8.5
+asgiref==3.8.1
+Django==4.2.22
+pytz==2025.2
+sqlparse==0.5.3
+djangorestframework==3.15.2
+psycopg2-binary==2.9.10

--- a/core/settings/__init__.py
+++ b/core/settings/__init__.py
@@ -1,0 +1,1 @@
+from .common import *

--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -41,10 +41,10 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
 
-    'dbp',
-    'products',
-    'customers',
-    'orders'
+    'dbp.apps.DbpConfig',
+    'products.apps.ProductsConfig',
+    'customers.apps.CustomersConfig',
+    'orders.apps.OrdersConfig'
 ]
 
 MIDDLEWARE = [
@@ -130,3 +130,14 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+import sys
+if 'test' in sys.argv:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }

--- a/dbp/tests.py
+++ b/dbp/tests.py
@@ -1,30 +1,31 @@
 from django.test import TestCase
 from django.utils.text import slugify
 
-from products.models import Color, Category, Product, Sku
-
 
 class ModelTests(TestCase):
 
     def test_create_category(self):
+        from products.models import Category
         category = Category(name="Categoria 1")
         category.save()
         self.assertIn(category.slug, slugify(category.name))
 
     def test_create_product(self):
+        from products.models import Category, Product
         category = Category.objects.create(name="Categoria 1")
         product = Product.objects.create(name='Product 1', category=category)
         self.assertIn(product.name, product.__str__())
 
     def test_create_color(self):
+        from products.models import Color
         color = Color(name="Red")
         color.save()
         self.assertIn(color.slug, 'red')
 
     def test_create_sku(self):
+        from products.models import Category, Product, Color, Sku
         category = Category.objects.create(name="Categoria 1")
         product = Product.objects.create(name='Product 1', category=category)
         color = Color.objects.create(name="Blue")
         sku, created = Sku.objects.get_or_create(product=product, color=color, size=1)
         self.assertIs(created, True)
-


### PR DESCRIPTION
This commit upgrades Django from version 3.0.5 to 4.2.22. It also updates other dependencies to be compatible with the new Django version.

The following changes were made to the code to ensure compatibility:
- Updated `INSTALLED_APPS` to use the `AppConfig` path for all local apps.
- Set `DEFAULT_AUTO_FIELD` to `BigAutoField` in the settings.
- Configured an in-memory SQLite database for running tests.
- Refactored tests to avoid circular dependencies and app loading issues.